### PR TITLE
Deploy regularly via schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
+  schedule:
+    - cron: '0 1 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
Tigger a deployment once per day to refresh the Mastodon posts as they are fetched once during the build run and not on every page reload.